### PR TITLE
Correction of some errors

### DIFF
--- a/GameServer/Cmd/CmdCardEquipInfo.cs
+++ b/GameServer/Cmd/CmdCardEquipInfo.cs
@@ -29,11 +29,11 @@ namespace GameServer.Cmd
             cei.efeito = IFNULL(_result.data[5]);
             cei.efeito_qntd = IFNULL(_result.data[6]);
             cei.slot = IFNULL(_result.data[7]);
-            if (_result.data[8] != null)
+            if (!_result.IsEmptyObject(8))
             {
                 cei.use_date.CreateTime(_translateDate(_result.data[8]));
             }
-            if (_result.data[9] != null)
+            if (!_result.IsEmptyObject(9))
             {
                 cei.end_date.CreateTime(_translateDate(_result.data[9]));
             }

--- a/GameServer/Cmd/CmdUserInfo.cs
+++ b/GameServer/Cmd/CmdUserInfo.cs
@@ -42,7 +42,7 @@ namespace GameServer.Cmd
                 m_ui.exp = _result.GetUInt32(20);
                 m_ui.level = _result.GetByte(21);
                 m_ui.pang =  _result.GetUInt64(22);
-                m_ui.media_score =  _result.GetUInt32(23);
+                m_ui.media_score =  _result.GetInt32(23);
                 for (i = 0; i < 5; i++)
                     m_ui.best_score[i] =  _result.GetByte(24 + i);    // 24 + 5
                 for (i = 0; i < 5; i++)

--- a/GameServer/PangType/pangya_game_st.cs
+++ b/GameServer/PangType/pangya_game_st.cs
@@ -525,7 +525,7 @@ namespace GameServer.PangType
         public uint exp { get; set; }
         public byte level { get; set; }
         public ulong pang { get; set; }
-        public uint media_score { get; set; }
+        public int media_score { get; set; }
         [field: MarshalAs(UnmanagedType.ByValArray, SizeConst = 5)]
         public byte[] best_score { get; set; }              // Best Score Por Estrela, mas acho que o pangya nao usa mais isso
         public byte event_flag { get; set; }
@@ -682,7 +682,7 @@ namespace GameServer.PangType
                 p.WriteUInt32(exp);
                 p.WriteByte(level);
                 p.WriteUInt64(pang);
-                p.WriteUInt32(media_score);             // Best Score Por Estrela, mas acho que o pangya nao usa mais isso
+                p.WriteInt32(media_score);             // Best Score Por Estrela, mas acho que o pangya nao usa mais isso
                 for (int i = 0; i < 5; i++)
                     p.WriteByte(best_score[i]);
                 p.WriteByte(event_flag);


### PR DESCRIPTION
### media_score

"media_score" value can have negative value, use signed instead unsigned.

### Card Equip

If condition is incorrect, it was still valid if the player had no cards. I reused your isEmptyObject function to correct the problem.